### PR TITLE
fix: handle async route params

### DIFF
--- a/src/app/dashboard/[planId]/page.tsx
+++ b/src/app/dashboard/[planId]/page.tsx
@@ -8,9 +8,9 @@ export const dynamic = 'force-dynamic';
 export default async function PlanPage({
   params,
 }: {
-  params: { planId: string };
+  params: Promise<{ planId: string }>;
 }) {
-  const { planId } = params;
+  const { planId } = await params;
   const supabase = supabaseServer();
 
   try {


### PR DESCRIPTION
## Summary
- fix PlanPage to await async route params and match Next.js 15 PageProps expectations

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a3c73b873c832ab51efb10e1edcec9