### PR TITLE
feat: add plan deletion

### DIFF
--- a/src/app/api/plan/route.ts
+++ b/src/app/api/plan/route.ts
@@ -26,3 +26,17 @@ export async function PUT(req: NextRequest) {
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });
   return NextResponse.json({ plan: data });
 }
+
+export async function DELETE(req: NextRequest) {
+  const supabase = supabaseRoute();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const { id } = await req.json();
+  const { error } = await supabase
+    .from('plans')
+    .update({ is_deleted: true })
+    .eq('id', id)
+    .eq('user_id', user.id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  return NextResponse.json({ success: true });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { supabaseServer } from '@/lib/supabaseServer';
+import PlanListItem from '@/components/PlanListItem';
 
 export default async function Dashboard() {
   const supabase = supabaseServer();
@@ -20,15 +21,7 @@ export default async function Dashboard() {
       </div>
       <ul className="space-y-2">
         {plans?.map((p) => (
-          <li key={p.id} className="border rounded p-3 bg-white text-gray-900">
-            <div className="flex items-center justify-between">
-              <div>
-                <div className="font-medium">{p.title}</div>
-                <div className="text-xs text-gray-500">{new Date(p.updated_at).toLocaleString()}</div>
-              </div>
-              <Link href={`/dashboard/${p.id}`} className="text-sm underline">Open</Link>
-            </div>
-          </li>
+          <PlanListItem key={p.id} plan={p} />
         ))}
       </ul>
     </div>

--- a/src/components/PlanListItem.tsx
+++ b/src/components/PlanListItem.tsx
@@ -1,0 +1,30 @@
+'use client';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+export default function PlanListItem({ plan }: { plan: { id: string; title: string; updated_at: string } }) {
+  const router = useRouter();
+  const remove = async () => {
+    if (!confirm('Delete this plan?')) return;
+    await fetch('/api/plan', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: plan.id }),
+    });
+    router.refresh();
+  };
+  return (
+    <li className="border rounded p-3 bg-white text-gray-900">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="font-medium">{plan.title}</div>
+          <div className="text-xs text-gray-500">{new Date(plan.updated_at).toLocaleString()}</div>
+        </div>
+        <div className="flex gap-2">
+          <Link href={`/dashboard/${plan.id}`} className="text-sm underline">Open</Link>
+          <button onClick={remove} className="text-sm text-red-600">Delete</button>
+        </div>
+      </div>
+    </li>
+  );
+}


### PR DESCRIPTION
## Summary
- support deleting plans via dashboard
- expose DELETE endpoint for plans API
- factor out plan list items with delete action

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a44b43dbec832ab2b4f93548e3c68f